### PR TITLE
Update pkt_netflow.c

### DIFF
--- a/pkt_netflow.c
+++ b/pkt_netflow.c
@@ -1834,7 +1834,7 @@ static struct ctl_path netflow_sysctl_path[] = {
 #endif /* CONFIG_SYSCTL */
 
 /* socket code */
-static void sk_error_report(struct sock *sk)
+void sk_error_report(struct sock *sk)
 {
 	struct pkt_netflow_sock *usock;
 


### PR DESCRIPTION
Hi, there is an error message when building in latest Ubuntu LTS:
`
$ ./configure
Kernel version: 5.15.0-48-generic (uname)
Kernel sources: /lib/modules/5.15.0-48-generic/build (found)
Checking for presence of include/linux/llist.h... Yes
Checking for presence of include/linux/grsecurity.h... No
Check for working gcc: Yes (gcc)
Searching for net-snmp-config... Yes /usr/bin/net-snmp-config
Searching for net-snmp agent... Yes.
Checking for DKMS... Yes.
Creating Makefile.. done.

  If you need some options enabled run ./configure --help
  Now run: make all install

$ make
./gen_compat_def > compat_def.h
Compiling for kernel 5.15.0-48-generic
make -C /lib/modules/5.15.0-48-generic/build M=/tmp/pkt-netflow modules CONFIG_DEBUG_INFO=y
make[1]: вход в каталог «/usr/src/linux-headers-5.15.0-48-generic»
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (Ubuntu 11.2.0-19ubuntu1) 11.2.0
  You are using:           gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
  CC [M]  /tmp/pkt-netflow/pkt_netflow.o
/tmp/pkt-netflow/pkt_netflow.c:1837:13: error: static declaration of ‘sk_error_report’ follows non-static declaration
 1837 | static void sk_error_report(struct sock *sk)
      |             ^~~~~~~~~~~~~~~
In file included from ./include/net/inet_sock.h:22,
                 from ./include/linux/udp.h:16,
                 from /tmp/pkt-netflow/pkt_netflow.c:32:
./include/net/sock.h:2333:6: note: previous declaration of ‘sk_error_report’ with type ‘void(struct sock *)’
 2333 | void sk_error_report(struct sock *sk);
      |      ^~~~~~~~~~~~~~~
In file included from /tmp/pkt-netflow/pkt_netflow.c:66:
/tmp/pkt-netflow/murmur3.h: In function ‘murmur3’:
/tmp/pkt-netflow/murmur3.h:35:28: warning: this statement may fall through [-Wimplicit-fallthrough=]
   35 |                 case 3: k1 ^= tail[2] << 16; /* FALLTHROUGH */
      |                         ~~~^~~~~~~~~~~~~~~~
/tmp/pkt-netflow/murmur3.h:36:17: note: here
   36 |                 case 2: k1 ^= tail[1] << 8;  /* FALLTHROUGH */
      |                 ^~~~
/tmp/pkt-netflow/murmur3.h:36:28: warning: this statement may fall through [-Wimplicit-fallthrough=]
   36 |                 case 2: k1 ^= tail[1] << 8;  /* FALLTHROUGH */
      |                         ~~~^~~~~~~~~~~~~~~
/tmp/pkt-netflow/murmur3.h:37:17: note: here
   37 |                 case 1: k1 ^= tail[0];
      |                 ^~~~
make[2]: *** [scripts/Makefile.build:297: /tmp/pkt-netflow/pkt_netflow.o] Ошибка 1
make[1]: *** [Makefile:1884: /tmp/pkt-netflow] Ошибка 2
make[1]: выход из каталога «/usr/src/linux-headers-5.15.0-48-generic»
make: *** [Makefile:23: pkt_netflow.ko] Ошибка 2
`
System information:
`
$ cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.1 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
$ uname -a
Linux hs-netadmin-4 5.15.0-48-generic #54-Ubuntu SMP Fri Aug 26 13:26:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
`